### PR TITLE
base_link frame added without a slash

### DIFF
--- a/kobuki_bumper2pc/src/kobuki_bumper2pc.cpp
+++ b/kobuki_bumper2pc/src/kobuki_bumper2pc.cpp
@@ -90,7 +90,7 @@ void Bumper2PcNodelet::onInit()
   n_side_y_ = - pc_radius_*cos(angle); // angle degrees from vertical
 
   // Prepare constant parts of the pointcloud message to be  published
-  pointcloud_.header.frame_id = "/base_link";
+  pointcloud_.header.frame_id = "base_link";
   pointcloud_.width  = 3;
   pointcloud_.height = 1;
   pointcloud_.fields.resize(3);


### PR DESCRIPTION
Tf2 requries frame_ids to not have a slash
